### PR TITLE
Create matrix first to speed up execution

### DIFF
--- a/R/rmpbart.r
+++ b/R/rmpbart.r
@@ -68,6 +68,8 @@ if(is.null(seedvalue)){
 	set.seed(seedvalue)
 }
 
+p = length(unique(y.train))
+
 XEx = NULL;
 for(i in 1:nrow(x.train)){
 XEx = rbind(XEx, matrix(rep(x.train[i,], p-1), byrow = TRUE, ncol = ncol(x.train) ) )
@@ -75,14 +77,12 @@ XEx = rbind(XEx, matrix(rep(x.train[i,], p-1), byrow = TRUE, ncol = ncol(x.train
 
 
 if(!is.na(x.test)[1]){
-	testXEx = NULL;
-	for(i in 1:nrow(x.test)){
-	testXEx = rbind(testXEx, matrix(rep(x.test[i,], p-1), byrow = TRUE, ncol = ncol(x.test) ) )
-	}
+	colnames(x.test) <- NULL
+	testXEx <- apply( x.test, 2, function(x) rep(as.matrix(x), each = p))
 } else {
 	testXEx = 0
 }
-p = length(unique(y.train))
+
 
 Data = list(p=p,y=y.train,X= XEx)
 

--- a/R/rmpbart.r
+++ b/R/rmpbart.r
@@ -77,8 +77,12 @@ XEx = rbind(XEx, matrix(rep(x.train[i,], p-1), byrow = TRUE, ncol = ncol(x.train
 
 
 if(!is.na(x.test)[1]){
-	colnames(x.test) <- NULL
-	testXEx <- apply( x.test, 2, function(x) rep(as.matrix(x), each = p))
+	# convert to matrix, including columns with factors
+	x.test = as.matrix(sapply(x.test, as.numeric))
+  	# get rid of the column headers for the matrix
+  	colnames(x.test) <- NULL
+  	# Create the new matrix
+  	testXEx <- apply( x.test, 2, function(x) rep(as.matrix(x), each = p))
 } else {
 	testXEx = 0
 }

--- a/R/rmpbart.r
+++ b/R/rmpbart.r
@@ -82,7 +82,7 @@ if(!is.na(x.test)[1]){
   	# get rid of the column headers for the matrix
   	colnames(x.test) <- NULL
   	# Create the new matrix
-  	testXEx <- apply( x.test, 2, function(x) rep(as.matrix(x), each = p))
+  	testXEx <- apply( x.test, 2, function(x) rep(as.matrix(x), each = p-1))
 } else {
 	testXEx = 0
 }
@@ -184,10 +184,10 @@ testX = testData$X
                sigmasample = sigmasample,
 			   PACKAGE="mpbart")      
 
-class_prob_train = res$trainpred
+class_prob_train = matrix(res$trainpred,ncol = p, byrow = TRUE)
 predicted_class_train = apply(class_prob_train,1,which.max)
 
-class_prob_test =  res$testpred
+class_prob_test = matrix(res$testpred,ncol = p, byrow = TRUE)
 predicted_class_test = apply(class_prob_test,1,which.max)
 
 ret = list(class_prob_train = class_prob_train, 

--- a/R/rmpbart.r
+++ b/R/rmpbart.r
@@ -184,10 +184,10 @@ testX = testData$X
                sigmasample = sigmasample,
 			   PACKAGE="mpbart")      
 
-class_prob_train = matrix(res$trainpred,ncol = p, byrow = TRUE)
+class_prob_train = res$trainpred
 predicted_class_train = apply(class_prob_train,1,which.max)
 
-class_prob_test = matrix(res$testpred,ncol = p, byrow = TRUE)
+class_prob_test =  res$testpred
 predicted_class_test = apply(class_prob_test,1,which.max)
 
 ret = list(class_prob_train = class_prob_train, 


### PR DESCRIPTION
When the dataframe is very large this loop creates bottleneck and slows down the execution speed. It's much faster to create the matrix ahead of time and fill it using an `apply` function, than it is to sequentially append new records.  